### PR TITLE
Fix client deletion in Admin panel

### DIFF
--- a/src/hooks/useClientManagement.tsx
+++ b/src/hooks/useClientManagement.tsx
@@ -64,6 +64,21 @@ export const useClientManagement = () => {
     }
   };
 
+  const handleDeleteClient = async (id: string) => {
+    try {
+      const response = await fetch(`/api/client?id=${id}`, {
+        method: "DELETE",
+      });
+      if (response.ok) {
+        await fetchClients();
+      } else {
+        console.error("Failed to delete client");
+      }
+    } catch (error) {
+      console.error("Error deleting client:", error);
+    }
+  };
+
   const fetchClients = async () => {
     try {
       const response = await fetch("/api/client");
@@ -87,5 +102,6 @@ export const useClientManagement = () => {
     handleCreateClient,
     handleUpdateClient,
     handleSaveClient,
+    handleDeleteClient,
   };
 };

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -88,6 +88,7 @@ const Admin = ({ initialProducts, orders }) => {
     handleCreateClient,
     handleUpdateClient,
     handleSaveClient,
+    handleDeleteClient,
   } = useClientManagement();
 
   const { ordersList, deleteOrder, editOrder, fabricante } =
@@ -134,7 +135,7 @@ const Admin = ({ initialProducts, orders }) => {
             clients={clients}
             openClientForm={openClientForm}
             editClient={openClientForm}
-            deleteClient={handleSaveClient}
+            deleteClient={handleDeleteClient}
           />
         </TabsContent>
 


### PR DESCRIPTION
## Summary
- implement `handleDeleteClient` in client management hook
- use the new deletion function in the admin clients tab

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683b8b5949f88325a07f7d6a53914684