### PR TITLE
Fix product duplication API route

### DIFF
--- a/src/pages/api/products/index.ts
+++ b/src/pages/api/products/index.ts
@@ -11,6 +11,16 @@ export default async function handler(req, res) {
       console.error("Error fetching products:", error);
       res.status(500).json({ message: "Internal Server Error" });
     }
+  } else if (req.method === "POST") {
+    try {
+      await connectToDatabase();
+      const newProduct = new Product(req.body);
+      await newProduct.save();
+      res.status(201).json(newProduct);
+    } catch (error) {
+      console.error("Error creating product:", error);
+      res.status(500).json({ message: "Internal Server Error" });
+    }
   } else {
     res.status(405).json({ message: "Method Not Allowed" });
   }


### PR DESCRIPTION
## Summary
- enable POST in `/api/products` to create products

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852b8d5212883258a26ac5daf11349f